### PR TITLE
Tweaks for popup

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -15,6 +15,7 @@ body {
 }
 iframe{
   width: 100%;
+  height: -webkit-fill-available;
   overflow: hidden;
   border: 0;
 }
@@ -323,4 +324,12 @@ textarea{
   background-color:transparent;
   border-bottom: 2px solid #fff;
   border-radius: 0;
+}
+
+.nav>li>a:hover {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.nav-tabs>li>a:hover {
+  border: none !important;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Lato:300,400,700,900');
 html, body {
   overflow-x: hidden;
   height: 100%;
@@ -1457,3 +1456,21 @@ input[type=checkbox]:checked ~ .sidebarIconToggle > .diagonal.part-1 {
   color: #fff!important;
 }
 */
+
+/* --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- 
+* For min res 1300px and max res 1900px 
+* Without these media queries, the "Ok, I'm done" button 
+* is not visible on 1366w resoultion and the user 
+* has to either enter fullscreen or to enter dev tools in order to 
+* use the button 
+* --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- */
+
+@media (min-width: 1300px) and (max-width: 1900px) {
+  #wizardOverlay h1 {
+    margin-top: 50px;
+    margin-bottom: 50px;
+  }
+  #wizardcats li {
+    width: 156px;
+  }
+}

--- a/src/views/newtab.html
+++ b/src/views/newtab.html
@@ -3,7 +3,8 @@
 
 <head>
   <title></title>
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,400,700,900">
   <link rel="stylesheet" href="../css/bootstrap.min.css">
   <link rel="stylesheet" href="../css/fontawesome/css/font-awesome.css">
   <link rel='stylesheet' href='../css/style.css'>


### PR DESCRIPTION
- The login buttons for both social media platforms are now visible.
- The "Ok, I'm done" button can now be clicked on resolutions between `1300px` and `1900px`. 
Before this fix, the user would have to either enter fullscreen mode in order to click the button or to enter developer tools in order to click the button.
- Font `Lato` is in `newtab.html` because of performance. 
`@import` in `CSS` slows down the app.
- Background colour for `Creator` and `Settings` tab.