### PR TITLE
Added Service Worker

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,53 @@
+// Cache name
+var CACHE = 'moonly';
+
+// Cache all of the files upong install event
+addEventListener('install', e => {
+    e.waitUntil(
+        caches.open(CACHE).then(cache => {
+            return cache.addAll([
+                '//fonts.googleapis.com/icon?family=Material+Icons',
+                '//fonts.googleapis.com/css?family=Lato:300,400,700,900',
+                '../css/bootstrap.min.css',
+                '../css/fontawesome/css/font-awesome.css',
+                '../css/style.css',
+                '../css/cat-colors.css',
+                '../js/libs/chrome-promise.js',
+                '../js/libs/jquery.min.js',
+                '../js/libs/bootstrap.min.js',
+                '../js/libs/moment.js',
+                '../js/libs/sha256.min.js',
+                '../js/libs/sockjs.min.js',
+                '../js/config.js',
+                '../js/popup/query.js',
+                '../js/newtab/jquery.nicescroll.js',
+                '../js/newtab/loginTest.js',
+                '../js/newtab/script.js'
+            ]);
+        })
+    );
+});
+
+// Fetch from cache first, then update the cache from network
+addEventListener('fetch', e => {
+    e.respondWith(fromCache(e.request));
+    e.waitUntil(updateCache(e.request));
+})
+
+// Load from cache
+let fromCache = req => {
+    return caches.open(CACHE).then(cache => {
+        return cache.match(req).then(res => {
+            return res || Promise.reject('no-match');
+        });
+    });
+};
+
+// Update the cache from network
+let updateCache = req => {
+    return caches.open(CACHE).then(cache => {
+        return fetch(req).then(res => {
+            return cache.put(request, res);
+        });
+    });
+};

--- a/src/views/newtab.html
+++ b/src/views/newtab.html
@@ -78,6 +78,15 @@
   
   <script src='../js/newtab/loginTest.js'></script>
   <script src='../js/newtab/script.js'></script>
+  <!-- Service Worker -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../service-worker.js', {scope: '../newtab.html'})
+      .catch(err => {
+        console.error(`Failed to register Service Worker, ${err.message}`);
+      });
+    };
+  </script>
  
 </body>
 


### PR DESCRIPTION
Lines **9** & **10** in `service-worker.js` might cause problems during the caching of the files, because lines **9** & **10** are external resources.

Not sure if the `{scope: '../newtab.html'}` is configured properly, please double check it. 
The Service Worker only needs to cache the files for `newtab.html`, but I'm not sure if the path for the scope is configured properly. 
If you put the scope to root, then it will surely cause major problems to the extension because it will try to cache files that are not defined at **install** event.  